### PR TITLE
Remove leader election handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -66,12 +66,6 @@ type SerfEventHandler struct {
 	// IsLeader determines if the local node is the cluster leader.
 	IsLeader IsLeaderFunc
 
-	// IsLeaderEventFunc determines if an event is a leader election event based on the event name.
-	IsLeaderEvent func(string) bool
-
-	// LeaderElectionHandler processes leader election events.
-	LeaderElectionHandler UserEventHandler
-
 	// UserEvent processes known, non-leader election events.
 	UserEvent UserEventHandler
 
@@ -200,15 +194,6 @@ func (s *SerfEventHandler) reconcile(me serf.MemberEvent) {
 // handleUserEvent is called when a user event is received from both local and remote nodes.
 func (s *SerfEventHandler) handleUserEvent(event serf.UserEvent) {
 	switch name := event.Name; {
-
-	// Handles leader election events
-	case s.IsLeaderEvent(name):
-		s.Logger.Info("serfer: New leader elected: %s", event.Payload)
-
-		// Process leader election event
-		if s.LeaderElectionHandler != nil {
-			s.LeaderElectionHandler.HandleUserEvent(event)
-		}
 
 	// Handle service events
 	case s.isServiceEvent(name):

--- a/handler_test.go
+++ b/handler_test.go
@@ -38,9 +38,6 @@ func (suite *EventHandlerTestSuite) SetupTest() {
 		IsLeader: func() bool {
 			return true
 		},
-		IsLeaderEvent: func(name string) bool {
-			return name == suite.Prefix+":new-leader"
-		},
 		Logger: &log.NullLogger{},
 	}
 
@@ -309,27 +306,6 @@ func (suite *EventHandlerTestSuite) TestUnknownEvent() {
 	u1.AssertNotCalled(suite.T(), "HandleUserEvent")
 	q1.AssertNotCalled(suite.T(), "HandleQueryEvent")
 	r1.AssertNotCalled(suite.T(), "Reconcile")
-}
-
-// Test leader election events are dispatched properly
-func (suite *EventHandlerTestSuite) TestUserEvent_LeaderElection() {
-
-	// Create Member Event
-	evt := serf.UserEvent{
-		LTime:    serf.LamportTime(0),
-		Name:     suite.Prefix + ":new-leader",
-		Payload:  make([]byte, 0),
-		Coalesce: false,
-	}
-
-	// Add UserEvent handler
-	m := &MockUserEventHandler{}
-	m.On("HandleUserEvent", evt).Return()
-	suite.Handler.LeaderElectionHandler = m
-
-	// Process event
-	suite.Handler.HandleEvent(evt)
-	m.AssertCalled(suite.T(), "HandleUserEvent", evt)
 }
 
 // Test unknown user events are dispatched properly


### PR DESCRIPTION
Leader election is treated as a special type of user event. It's not special enough to be a separate event handler. Removing this so the application can handle it.
